### PR TITLE
update with information from current state of product

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -104,7 +104,7 @@ The following example shows an item in the [[#json-representation]]:
 </pre>
 </div>
 
-ISSUE(openregister/specification#3): IMPLEMENTATION the path to an item is currently implemented as /hash/{item-hash} and returns a record, not an item.
+ISSUE(openregister/specification#3): IMPLEMENTATION the current item URL returns a fat entry, not an item.
 
 ## Entry resource ## {#entry-resource}
 


### PR DESCRIPTION
currently, the URL for an item is at `/item/blah` eg
https://country.register.gov.uk/item/b24b537412095cd50fadce010fdeefeb5d3a4b71
-- however the content is still a fat entry rather than an item.
