### PR TITLE
use fixed bikeshed fork

### DIFF
--- a/index.html
+++ b/index.html
@@ -1334,7 +1334,7 @@
     <div style="border-left: 3px solid; border-color: #005abb; padding: 40px 0 0 10px; background-image: url(https://assets.digital.cabinet-office.gov.uk/government/assets/crests/org_crest_27px.png); background-position: 9px top; background-size: auto 40px; background-repeat: no-repeat; margin-bottom: 2em; font-family: &apos;Helvetica&apos;, sans-serif;"> <a href="https://www.gov.uk/government/organisations/government-digital-service" title="Government Digital Service (GDS)">Government Digital Service</a> </div>
    </p>
    <h1 class="p-name no-ref" id="title">Open Registers</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-06-23">23 June 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-07-25">25 July 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Pygments==2.1
 lxml==3.5.0
--e git+git@github.com:tabatkins/bikeshed.git@41d8438d47b17f60359ac8ec4afca6b5ef56effd#egg=Bikeshed-master
+-e git+git@github.com:openregister/bikeshed.git@2ea965dedebe2671cf4b41da8bad0790c0241f77#egg=Bikeshed-master


### PR DESCRIPTION
Bikeshed depends on html5lib which has moved a namespace that bikeshed was depending on.

You can see more details in openregister/bikeshed@2ea965dedebe2671cf4b41da8bad0790c0241f77.
