### PR TITLE
Update from RFC5988 to RFC8288

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -166,7 +166,7 @@ This resource is provided as a convenience: in principle, it can be
 computed by a client by replaying the log of all entries and finding
 the latest one with the given primary key value.
 
-This resource SHOULD provide a Link: header [[RFC5988]] with a
+This resource SHOULD provide a <code>Link:</code> header [[RFC8288]] with a
 relation of <code>"version-history"</code> [[RFC5829]] to the
 [[#record-entries-resource]] for this record.
 
@@ -378,7 +378,12 @@ An instance of an [[#item-resource]] and an [[#entry-resource]] are both deemed 
 
 # Collection resources # {#list-resources}
 
-There is a limit to how many records or entries can be returned in a single request. To fetch more, pagination is used. Pagination is supported through an http link header [[RFC5988]], with a link rel="next" for the next page, and rel="previous" for the previous page. On the first page, there is no "previous" link, and on the last page there is no "next" link.
+There is a limit to how many records or entries can be returned in a single
+request. To fetch more, pagination is used. Pagination is supported through an
+http link header [[RFC8288]], with a link <code>rel="next"</code> for the next
+page, and <code>rel="previous"</code> for the previous page. On the first
+page, there is no <code>"previous"</code> link, and on the last page there is
+no <code>"next"</code> link.
 
 ISSUE(openregister/specification#7): define query string parameters ..
 
@@ -624,7 +629,7 @@ A register archive MAY contain entry and item resources in the more space effici
 
 Table of link and other HTTP headers used by resources ..
 
-  * [[RFC5988]]
+  * [[RFC8288]]
   * <a href="http://www.iana.org/assignments/link-relations/link-relations.xhtml">link-relations</a>
   * [[#immutable-resources]] SHOULD be served with a long-lived Cache-Control max-age value [[RFC7234]].
   * the [[#item-hash-field]] SHOULD be served as the etag header value for an [[#item-resource]].


### PR DESCRIPTION
RFC5988 has been superseded by [RFC8288](https://tools.ietf.org/html/rfc8288). This PR updates all references to RFC8288.