### PR TITLE
Fix datetime datatype. Timezone Z (UTC) is required and not implicit

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -628,6 +628,7 @@ Optional:
                   Sequence:
                     T: :
                     T: SS
+        T: Z
 </pre>
 
 
@@ -639,7 +640,7 @@ Optional:
 <div class="example">
   The following examples are all valid Datetime values: 
   <pre>
-    "2001", "2001-01", "2001-01-31", "2001-01-31T23:20:55"
+    "2001", "2001-01", "2001-01-31", "2001-01-31T23:20:55Z"
   </pre>
 </div>
 


### PR DESCRIPTION
The current spec requires datetime values to not have timezone including not having `Z`. The missing timezone makes the UTC requirement implicit to any tool that consumes the value.

The ISO8601 says that when a time component has no timezone defined it is assumed local time which contradicts the registers specification and any tool compliant with the ISO8601 standard.

This PR requires an explicit `Z` for any datetime with time component in it to guarantee UTC is not assumed but declared.