### PR TITLE
Define how to generate the hash entry for V1

### DIFF
--- a/content/v1/entry-def.md
+++ b/content/v1/entry-def.md
@@ -71,3 +71,19 @@ The identity of an entry computed from its content. It is used for
 
 The function takes an entry and a hashing algorithm and returns a [Hash
 datatype](/v1/datatypes/hash).
+
+```elm
+hash : Entry -> HashingAlgorithm -> Hash
+```
+
+To compute the entry hash you need to [represent the entry as
+json](/v1/rest-api/entries) and remove all non-significant spaces:
+
+```json
+{"index-entry-number":"72","entry-number":"72","entry-timestamp":"2016-04-05T13:23:05Z","key": "GH","item-hash":["sha-256:dc1d12943ea264de937468b254286e5ebd8acd316e21bf667076ebdb8c111bd1"]}
+```
+
+And then hash it with the register `HashingAlgorithm`.
+
+Notice that the entry representation is a single JSON object but the API
+always returns an array.

--- a/content/v1/entry-resource.md
+++ b/content/v1/entry-resource.md
@@ -55,8 +55,8 @@ Content-Type: application/json
 
 [
   {
-    "index-entry-number": 72,
-    "entry-number": 72,
+    "index-entry-number": "72",
+    "entry-number": "72",
     "entry-timestamp": "2016-04-05T13:23:05Z",
     "key": "GH",
     "item-hash": [
@@ -106,8 +106,8 @@ Link: </entries?start=101>; rel="next"
 
 [
   {
-    "index-entry-number": 1,
-    "entry-number": 1,
+    "index-entry-number": "1",
+    "entry-number": "1",
     "entry-timestamp": "2015-08-15T08:15:30Z",
     "key": "402019",
     "item-hash": [
@@ -115,8 +115,8 @@ Link: </entries?start=101>; rel="next"
     ]
   },
   {
-    "index-entry-number": 2,
-    "entry-number": 2,
+    "index-entry-number": "2",
+    "entry-number": "2",
     "entry-timestamp": "2015-08-20T08:15:30Z",
     "key": "402020",
     "item-hash": [
@@ -124,8 +124,8 @@ Link: </entries?start=101>; rel="next"
     ]
   },
   {
-    "index-entry-number": 3,
-    "entry-number": 3,
+    "index-entry-number": "3",
+    "entry-number": "3",
     "entry-timestamp": "2015-08-21T00:00:00Z",
     "key": "402020",
     "item-hash": [
@@ -159,8 +159,8 @@ Link: </entries?start=201>; rel="next", </entries?start=1>; rel="previous"
 
 [
   {
-    "index-entry-number": 101,
-    "entry-number": 101,
+    "index-entry-number": "101",
+    "entry-number": "101",
     "entry-timestamp": "2016-04-05T13:23:05Z",
     "key": "KG",
     "item-hash": [
@@ -168,8 +168,8 @@ Link: </entries?start=201>; rel="next", </entries?start=1>; rel="previous"
     ]
   },
   {
-    "index-entry-number": 102,
-    "entry-number": 102,
+    "index-entry-number": "102",
+    "entry-number": "102",
     "entry-timestamp": "2016-04-05T13:23:05Z",
     "key": "LA",
     "item-hash": [


### PR DESCRIPTION
### Context

The registers specification never had the definition of how to obtain the entry hash used for merkle tree proofs. The reference implementation, ORJ, does it and this has made it a precedent that we need to keep for backwards compatibility.

### Changes proposed in this pull request

Describes how to hash the entry in V1.

### Guidance to review

It is comprehensive.
